### PR TITLE
Changed reference to execSync to work with later nodejs versions

### DIFF
--- a/template/tasks/dploy.coffee
+++ b/template/tasks/dploy.coffee
@@ -5,7 +5,7 @@ dploy    = require "dploy"
 inquirer = require "inquirer"
 YAML     = require "yamljs"
 When     = require "when"
-execSync = require "execSync"
+execSync = require("child_process").execSync
 
 
 settings    = require "./settings"


### PR DESCRIPTION
There was a reference to execSync in dploy.coffee that needed to be changed too.
